### PR TITLE
Really fixed selector for "Remove tag" button. (Capitalisation is inconsistent!)

### DIFF
--- a/cleaner.py
+++ b/cleaner.py
@@ -172,6 +172,13 @@ class FacebookCleaner(object):
                 xpath, required, action = xpath_components
             else:
                 raise Exception('Invalid arguments to perform_xpaths {0}'.format(xpath_components))
+
+            # Transform lower-case into translate function as it is not included with
+            # xpath 1.0 (It's useful for performing case-insensitive matching.)
+            xpath = re.sub(r"lower-case\((.+?)\),",
+                           r"translate(\1, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),",
+                           xpath)
+
             elem=self.driver.find_elements_by_xpath(xpath)
             if elem:
                 elem=elem[0]
@@ -230,7 +237,7 @@ class FacebookCleaner(object):
         over the username and the click remove tag to remove the tag.
         '''
         xpaths=[("//a[contains(@class,'taggee') and contains(text(), '{0}')]".format(self.name), True,'hover'),
-                ("//a[contains(text(), 'Remove tag')]",True,),
+                ("//a[contains(lower-case(text()), 'remove tag')]",True,),
                 ("//button[contains(text(), 'Okay')]", False,),]
         return self.perform_xpaths(url, xpaths)
 

--- a/cleaner.py
+++ b/cleaner.py
@@ -238,7 +238,7 @@ class FacebookCleaner(object):
         '''
         xpaths=[("//a[contains(@class,'taggee') and contains(text(), '{0}')]".format(self.name), True,'hover'),
                 ("//a[contains(lower-case(text()), 'remove tag')]",True,),
-                ("//button[contains(text(), 'Okay')]", False,),]
+                ("//button[contains(@class, 'Confirm')]", False,),]
         return self.perform_xpaths(url, xpaths)
 
     def album_generator(self):


### PR DESCRIPTION
Sorry, one final pull request honest!

I realised that the "Remove tag" button has variable cApItAliSaTiOn so I've adjusted the xpath to handle that. Unforunately the lower-case function is not available in Xpath 1.0 (what we have access to) so I've implemented a hack to allow us to use it.

I wrote a regexp that transforms a call like `lower-case('something')` to `translate('something', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')`. ([See this Stack overflow post](http://stackoverflow.com/questions/2893551/case-insensitive-matching-in-xpath))

To handle nested parenthesis properly with such a regexp is not possible without the ability to recurse... and we don't have that either. The compromise I made to keep this simple was to assume that the lower case call will always end with `),`.
So for example:
- This will correctly match the regexp `"//a[contains(lower-case(text()), 'remove tag')]"`
- This will also work correctly `"//a[contains(lower-case('first part second part'), 'remove tag')]"`
- This would not match at all `"//a[contains('remove tag', lower-case(text()))]"` when it should really.
- This will match incorrectly `"//a[contains(lower-case("first part), second part"), 'remove tag')]"` as there is a `),` string inside the string.

I can't see any situation where these limitations matter in practice and they allow us to keep the code quite simple. I thought it was worth mentioning though and it's something you might want to re-do in the future.

The cool thing with all of this is that you can now use `lower-case` for any xpaths should you find that Facebook is being inconsistent with capitalisation else where.
